### PR TITLE
Add optional OSM2World scene rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,17 @@ frontend/dist/
 artifacts/
 running_log.log
 server.*.log
+tools/osm2world/*.zip
+# Java and OSM2World are external runtime dependencies and may be large.
+tools/java/
+tools/osm2world/OSM2World.jar
+tools/osm2world/lib/
+tools/osm2world/locales/
+tools/osm2world/models/
+tools/osm2world/resources/
+tools/osm2world/textures/
+tools/osm2world/LICENSE.txt
+tools/osm2world/standard.properties
+tools/osm2world/osm2world-windows.bat
+tools/osm2world/osm2world.sh
+tests/

--- a/README.md
+++ b/README.md
@@ -57,6 +57,72 @@ cd ..
 .\.venv\Scripts\python.exe main.py serve --host 127.0.0.1 --port 8000
 ```
 
+## OSM2World detailed rendering (optional)
+
+OSM2World is an optional visual sidecar. It adds detailed building, roof, road
+and surface appearance to the web console, while the original Sionna scene
+remains the source of truth for radio propagation, collision geometry and
+simulation logic. If OSM2World or Java is unavailable, the scene still
+compiles and the console falls back to the built-in geometry renderer.
+
+### Download the optional dependencies
+
+1. Download the **latest build** from the official OSM2World page:
+   [OSM2World latest build](https://osm2world.org/download/files/latest/OSM2World-latest-bin.zip).
+   Choose **latest build** on the download page. Do not choose **old releases
+   and resources** for a normal installation. The numbered [0.4.0 release](https://osm2world.org/download/files/0.4.0/OSM2World-0.4.0-bin.zip)
+   is an older fallback, not the recommended download.
+2. Windows x64 users need only this one Java package:
+   [Eclipse Temurin 17 JRE ZIP](https://adoptium.net/temurin/releases/?version=17&os=windows&arch=x64&package=jre).
+   Eclipse Temurin is the Java distribution; JRE is the runtime package. Do
+   not download both JRE and JDK. Choose the [Temurin 17 JDK ZIP](https://adoptium.net/temurin/releases/?version=17&os=windows&arch=x64&package=jdk)
+   only if Java development tools are needed or a JRE ZIP is unavailable.
+3. Extract both ZIP files into this project-local layout:
+
+```text
+UavNetSim-master/
+└── tools/
+    ├── java/
+    │   └── jdk-17.../ or jre-17.../
+    │       └── bin/java.exe
+    └── osm2world/
+        ├── OSM2World-latest.jar
+        ├── lib/
+        ├── models/
+        ├── resources/
+        └── textures/
+```
+
+The extracted directory and JAR names may vary. The application searches
+`tools/java` and recursively searches `tools/osm2world` for an OSM2World JAR.
+These external runtime files are ignored by Git and must be installed locally
+after cloning; do not commit them.
+
+Verify the installation from the project root:
+
+```powershell
+tools/osm2world/run-osm2world.cmd --help
+```
+
+You can also set `OSM2WORLD_JAR` or pass `--osm2world-jar`. To keep the
+enriched OSM file but disable the optional renderer, use `--no-osm2world`:
+
+```powershell
+.venv/Scripts/python.exe main.py compile-scene scenarios/default_scene.json --output artifacts/scene
+.venv/Scripts/python.exe main.py compile-scene scenarios/default_scene.json --output artifacts/scene --no-osm2world
+```
+
+The normal first-start sequence is:
+
+```powershell
+cd frontend
+npm ci
+npm run build
+cd ..
+.venv/Scripts/python.exe main.py compile-scene scenarios/default_scene.json --output artifacts/scene
+.venv/Scripts/python.exe main.py serve --host 127.0.0.1 --port 8000
+```
+
 ## Features
 Before you start your simulation journey, we recommend that you read this section first, in which some features of this platform are mentioned so that you can decide if this platform meets your development or research needs.
 - Python-based (this simulation platform is developed based on SimPy library in Python);

--- a/README_CHINESE.md
+++ b/README_CHINESE.md
@@ -41,6 +41,86 @@
 - scikit_opt==0.6.6
 - simpy==4.1.1
 
+## 安装及使用
+
+### 基本环境
+
+项目运行需要 Python 3.11 或更高版本，以及 Node.js 18 或更高版本和 npm。
+在项目根目录执行：
+
+```powershell
+py -3.12 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install --upgrade pip
+.\.venv\Scripts\python.exe -m pip install -e .
+
+cd frontend
+npm ci
+npm run build
+cd ..
+```
+
+### OSM2World 详细外观渲染（可选）
+
+OSM2World 只是可选的可视化组件，用于为网页控制台增加更详细的建筑、屋顶、道路和地面外观。
+它不会替换 Sionna 的无线传播场景、碰撞几何或仿真逻辑。没有安装 OSM2World 或 Java 时，项目仍然可以编译场景，并自动回退到内置的建筑和地面渲染。
+
+#### 下载哪个 OSM2World 版本
+
+请打开 [OSM2World 官方下载页](https://osm2world.org/download/)，在 **Releases** 中选择 **latest build**，或直接下载 [OSM2World latest build](https://osm2world.org/download/files/latest/OSM2World-latest-bin.zip)。
+
+不要为正常安装选择 **old releases and resources**。页面中的 [0.4.0](https://osm2world.org/download/files/0.4.0/OSM2World-0.4.0-bin.zip) 是旧的编号版本，仅作为兼容性备用版本，不是本项目推荐的下载项。
+
+#### Java 下载哪个文件
+
+Windows x64 用户只需要下载下面这一个文件：[Eclipse Temurin 17 JRE ZIP](https://adoptium.net/temurin/releases/?version=17&os=windows&arch=x64&package=jre)。
+
+这里的关系是：**Eclipse Temurin** 是 Java 的发行版，**JRE** 是用于运行 Java 程序的运行环境，**JDK** 是包含开发工具的完整开发包。运行 OSM2World 只需要 JRE，不需要同时下载 JRE 和 JDK。只有在需要 Java 开发工具，或下载页面没有 JRE ZIP 时，才选择 [Temurin 17 JDK ZIP](https://adoptium.net/temurin/releases/?version=17&os=windows&arch=x64&package=jdk)。
+
+在下载页面选择 **Windows、x64、JRE、ZIP**。推荐 ZIP 是因为可以直接放入项目目录，不需要修改系统环境变量。若电脑已经安装 Java 17 或更高版本，则不需要重复下载 Java。
+
+#### 解压到什么位置
+
+将两个 ZIP 解压到项目内的以下目录。文件夹和 JAR 文件的具体版本名称可以不同，不要强制改名：
+
+```text
+UavNetSim-master/
+└── tools/
+    ├── java/
+    │   └── jdk-17.../ 或 jre-17.../
+    │       └── bin/java.exe
+    └── osm2world/
+        ├── OSM2World-latest.jar
+        ├── lib/
+        ├── models/
+        ├── resources/
+        └── textures/
+```
+
+程序会自动搜索 `tools/java`，并在 `tools/osm2world` 中递归查找 OSM2World JAR。Java、OSM2World JAR、纹理和模型资源属于外部依赖，已通过 `.gitignore` 排除，不要将它们提交到 GitHub。
+
+安装后可在项目根目录验证：
+
+```powershell
+tools/osm2world/run-osm2world.cmd --help
+```
+
+如果未安装 OSM2World 或 Java，该命令会提示缺少的文件；项目本身仍然可以正常编译并使用内置渲染。也可以通过环境变量 `OSM2WORLD_JAR` 或命令行参数 `--osm2world-jar` 指定 JAR 路径。
+
+#### 启动项目
+
+首次安装完成后，先编译默认场景，再启动后端：
+
+```powershell
+.venv/Scripts/python.exe main.py compile-scene scenarios/default_scene.json --output artifacts/scene
+.venv/Scripts/python.exe main.py serve --host 127.0.0.1 --port 8000
+```
+
+浏览器打开 `http://127.0.0.1:8000`。以后如果前端代码没有变化，只需执行启动命令即可。若只想使用原有的内置场景渲染，同时仍生成 OSM 文件，可执行：
+
+```powershell
+.venv/Scripts/python.exe main.py compile-scene scenarios/default_scene.json --output artifacts/scene --no-osm2world
+```
+
 ## 特色
 在开始您的仿真之旅前，我们建议您先阅读本小节，本节中介绍了该平台的一些特点，您可以据此来判断该平台是否满足您的开发或研究需求。
 - 该平台完全基于Python开发（主要是基于Python中的SimPy库）；

--- a/api/app.py
+++ b/api/app.py
@@ -83,15 +83,15 @@ scene_builds: dict[str, SceneBuildState] = {}
 scene_build_lock = Lock()
 
 
-def _activate_scene(scene, progress=None):
+def _activate_scene(scene, progress=None, asset_version=None):
     output = config.PROJECT_ROOT / "artifacts" / "scene"
-    compile_scene(scene, output, progress)
+    compile_scene(scene, output, progress, asset_version=asset_version)
     config.SIONNA_SCENE_PATH = str(output / "scene.xml")
     config.MAP_LENGTH = scene.size_x
     config.MAP_WIDTH = scene.size_y
     terrain_height = max((point.z for point in scene.terrain.vertices), default=0.0) if scene.terrain else 0.0
     config.MAP_HEIGHT = terrain_height + config.AIRSPACE_HEIGHT_ABOVE_TERRAIN
-    return scene
+    return SceneModel.model_validate_json((output / "scene.json").read_text(encoding="utf-8"))
 
 
 def _update_scene_build(build_id, **changes):
@@ -121,7 +121,7 @@ def _run_scene_build(build_id, request):
         def compile_progress(value, stage):
             _update_scene_build(build_id, progress=55 + round(value * 43), stage=stage)
 
-        _activate_scene(scene, compile_progress)
+        scene = _activate_scene(scene, compile_progress, asset_version=f"build-{build_id}")
         _update_scene_build(
             build_id,
             status="completed",
@@ -265,6 +265,18 @@ async def event_stream(websocket: WebSocket):
 
 
 frontend = config.PROJECT_ROOT / "frontend" / "dist"
+artifacts = config.PROJECT_ROOT / "artifacts"
+artifacts.mkdir(parents=True, exist_ok=True)
+
+
+@app.get("/artifacts/{asset_path:path}")
+def artifact_file(asset_path: str):
+    candidate = (artifacts / asset_path).resolve()
+    if artifacts not in candidate.parents or not candidate.is_file():
+        raise HTTPException(404, "Artifact not found")
+    return FileResponse(candidate, headers={"Cache-Control": "no-store"})
+
+
 if frontend.is_dir():
     app.mount("/assets", StaticFiles(directory=frontend / "assets"), name="assets")
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,27 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+
+export default [
+  { ignores: ['dist/**'] },
+  {
+    files: ['**/*.{js,jsx}'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      parserOptions: { ecmaFeatures: { jsx: true } },
+      globals: { ...globals.browser, ...globals.node },
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      ...reactRefresh.configs.vite.rules,
+      'no-unused-vars': 'off',
+    },
+  },
+]

--- a/frontend/src/components/SceneViewport.jsx
+++ b/frontend/src/components/SceneViewport.jsx
@@ -1,7 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Canvas, useFrame, useThree } from '@react-three/fiber'
 import { Grid, Line, OrbitControls } from '@react-three/drei'
 import * as THREE from 'three'
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
+import { MTLLoader } from 'three/examples/jsm/loaders/MTLLoader.js'
+import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader.js'
 
 const MATERIAL_COLORS = {
   itu_concrete: '#5f6669',
@@ -13,21 +16,79 @@ const MATERIAL_COLORS = {
   itu_wet_ground: '#315a68',
 }
 
+function terrainHeightAt(terrain, sizeX, sizeY, x, y) {
+  if (!terrain) return 0
+  const column = THREE.MathUtils.clamp((x / sizeX) * (terrain.columns - 1), 0, terrain.columns - 1)
+  const row = THREE.MathUtils.clamp((y / sizeY) * (terrain.rows - 1), 0, terrain.rows - 1)
+  const left = Math.min(terrain.columns - 2, Math.floor(column))
+  const lower = Math.min(terrain.rows - 2, Math.floor(row))
+  const fractionX = column - left
+  const fractionY = row - lower
+  const base = lower * terrain.columns + left
+  const southwest = terrain.vertices[base].z
+  const southeast = terrain.vertices[base + 1].z
+  const northwest = terrain.vertices[base + terrain.columns].z
+  const northeast = terrain.vertices[base + terrain.columns + 1].z
+  const south = THREE.MathUtils.lerp(southwest, southeast, fractionX)
+  const north = THREE.MathUtils.lerp(northwest, northeast, fractionX)
+  return THREE.MathUtils.lerp(south, north, fractionY)
+}
+
 function CameraTarget({ scene }) {
   const controls = useRef()
   const { camera } = useThree()
   useEffect(() => {
     const scale = Math.max(scene.size_x, scene.size_y)
     const relief = Math.max(0, ...(scene.terrain?.vertices || []).map((point) => point.z))
-    camera.position.set(
-      scene.size_x * 1.25,
-      Math.max(scale, relief + scale * 0.65),
-      scene.size_y * 0.75,
+    const structureHeight = Math.max(
+      0,
+      ...scene.features
+        .filter((feature) => feature.category === 'building')
+        .map((feature) => (feature.footprint[0]?.z || 0) + feature.height),
     )
-    controls.current?.target.set(scene.size_x / 2, relief * 0.28 + 12, -scene.size_y / 2)
+    const viewHeight = Math.max(scale, relief + scale * 0.65, structureHeight * 1.8)
+    camera.position.set(scene.size_x * 1.25, viewHeight, scene.size_y * 0.75)
+    controls.current?.target.set(
+      scene.size_x / 2,
+      Math.max(relief * 0.28 + 12, structureHeight * 0.35),
+      -scene.size_y / 2,
+    )
     controls.current?.update()
   }, [camera, scene])
   return <OrbitControls ref={controls} makeDefault maxPolarAngle={Math.PI / 2.05} minDistance={40} maxDistance={1800} />
+}
+
+function Roof({ feature, baseHeight }) {
+  const roofShape = feature.osm_tags?.['roof:shape'] || 'flat'
+  const roofHeight = Number(feature.osm_tags?.['roof:height'] || 0)
+  const geometry = useMemo(() => {
+    if (roofShape === 'flat' || roofHeight <= 0.01) return null
+    const shape = new THREE.Shape()
+    feature.footprint.forEach((point, index) => {
+      if (index === 0) shape.moveTo(point.x, point.y)
+      else shape.lineTo(point.x, point.y)
+    })
+    shape.closePath()
+    const result = new THREE.ExtrudeGeometry(shape, {
+      depth: roofHeight,
+      bevelEnabled: roofShape === 'hipped' || roofShape === 'pyramidal',
+      bevelSegments: 1,
+      bevelSize: Math.min(1.2, roofHeight * 0.18),
+      bevelThickness: Math.min(1.2, roofHeight * 0.18),
+    })
+    result.rotateX(-Math.PI / 2)
+    return result
+  }, [feature, roofHeight, roofShape])
+  if (!geometry) return null
+  return (
+    <mesh geometry={geometry} position={[0, baseHeight + feature.height, 0]} castShadow receiveShadow>
+      <meshStandardMaterial
+        color={feature.osm_tags?.['roof:colour'] || '#8c6956'}
+        roughness={feature.osm_tags?.['roof:material'] === 'glass' ? 0.28 : 0.78}
+        metalness={feature.osm_tags?.['roof:material'] === 'metal' ? 0.32 : 0.04}
+      />
+    </mesh>
+  )
 }
 
 function Building({ feature, selected }) {
@@ -42,29 +103,203 @@ function Building({ feature, selected }) {
       else shape.lineTo(point.x, point.y)
     })
     shape.closePath()
-    const result = new THREE.ExtrudeGeometry(shape, {
-      depth: feature.height,
-      bevelEnabled: false,
-    })
+    const result = new THREE.ExtrudeGeometry(shape, { depth: feature.height, bevelEnabled: false })
     result.rotateX(-Math.PI / 2)
     return result
   }, [feature])
   return (
-    <mesh geometry={geometry} position={[0, baseHeight, 0]} castShadow receiveShadow>
-      <meshStandardMaterial
-        color={MATERIAL_COLORS[feature.material] || MATERIAL_COLORS.itu_concrete}
-        roughness={selected ? 0.36 : 0.62}
-        metalness={feature.material === 'itu_metal' ? 0.52 : 0.08}
-      />
-    </mesh>
+    <group>
+      <mesh geometry={geometry} position={[0, baseHeight, 0]} castShadow receiveShadow>
+        <meshStandardMaterial
+          color={feature.osm_tags?.['facade:colour'] || MATERIAL_COLORS[feature.material] || MATERIAL_COLORS.itu_concrete}
+          roughness={selected ? 0.36 : 0.62}
+          metalness={feature.material === 'itu_metal' ? 0.52 : 0.08}
+        />
+      </mesh>
+      <Roof feature={feature} baseHeight={baseHeight} />
+    </group>
   )
 }
 
-function Surface({ feature }) {
-  const baseHeight = useMemo(
-    () => feature.footprint.reduce((total, point) => total + (point.z || 0), 0) / feature.footprint.length,
-    [feature],
-  )
+function osm2WorldOriginPosition(object, scene) {
+  const origin = object.userData?.origin
+  const latitude = Number(origin?.lat)
+  const longitude = Number(origin?.lon)
+  if (Number.isFinite(latitude) && Number.isFinite(longitude)) {
+    const metresPerDegreeLongitude = Math.cos(THREE.MathUtils.degToRad(scene.anchor.latitude)) * 111320
+    return {
+      x: (longitude - scene.anchor.longitude) * metresPerDegreeLongitude,
+      z: -(latitude - scene.anchor.latitude) * 110574,
+    }
+  }
+  return { x: scene.size_x / 2, z: -scene.size_y / 2 }
+}
+
+function alignOsm2WorldModel(object, scene) {
+  const origin = osm2WorldOriginPosition(object, scene)
+  object.position.x = origin.x
+  object.position.z = origin.z
+  const bounds = new THREE.Box3().setFromObject(object)
+  object.position.y -= bounds.min.y
+}
+
+function featureForOsm2WorldObject(object, scene, fallbackIndex, category) {
+  const identifier = object.userData?.osmId || object.name || ''
+  const match = String(identifier).match(/w(-?\d+)$/)
+  if (match) {
+    const featureIndex = -Number(match[1]) - 2000000000
+    const feature = scene.features[featureIndex]
+    if (feature?.category === category) return feature
+  }
+  return scene.features.filter((feature) => feature.category === category)[fallbackIndex] || null
+}
+
+function osm2WorldSurfaceKind(child) {
+  const name = child.name.toUpperCase()
+  const materials = Array.isArray(child.material) ? child.material : [child.material]
+  const materialNames = materials.map((material) => material?.name?.toUpperCase() || '')
+  if (name.startsWith('WATER') || materialNames.some((name) => name === 'WATER' || name.includes('WATER'))) return 'water'
+  if (name.startsWith('ROAD') || materialNames.some((name) => name === 'ASPHALT')) return 'road'
+  if (name.startsWith('SURFACEAREA')) return 'land'
+  if (materialNames.some((name) => name === 'TERRAIN_DEFAULT' || name === 'GRASS')) return 'land'
+  return null
+}
+
+function osm2WorldSurfaceLayers(object) {
+  const layers = { road: false, water: false }
+  object.traverse((child) => {
+    const kind = osm2WorldSurfaceKind(child)
+    if (kind === 'road' || kind === 'water') layers[kind] = true
+  })
+  return layers
+}
+
+function hasOsm2WorldSurfaceAncestor(object, kind) {
+  let ancestor = object.parent
+  while (ancestor) {
+    if (osm2WorldSurfaceKind(ancestor) === kind) return true
+    ancestor = ancestor.parent
+  }
+  return false
+}
+
+function drapeOsm2WorldSurface(root, scene, feature, kind) {
+  if (!scene.terrain) return
+  const bounds = new THREE.Box3().setFromObject(root)
+  const baseHeight = bounds.min.y
+  const lift = kind === 'water' ? 0.18 : feature?.osm_tags?.bridge === 'yes' ? 1.5 : 0.28
+  const position = new THREE.Vector3()
+  root.traverse((child) => {
+    if (!child.isMesh || !child.geometry?.attributes?.position) return
+    const positions = child.geometry.attributes.position
+    for (let index = 0; index < positions.count; index += 1) {
+      position.fromBufferAttribute(positions, index)
+      child.localToWorld(position)
+      const relativeHeight = position.y - baseHeight
+      position.y = terrainHeightAt(scene.terrain, scene.size_x, scene.size_y, position.x, -position.z) + lift + relativeHeight
+      child.worldToLocal(position)
+      positions.setXYZ(index, position.x, position.y, position.z)
+    }
+    positions.needsUpdate = true
+    child.geometry.computeVertexNormals()
+    child.geometry.computeBoundingBox()
+    child.geometry.computeBoundingSphere()
+  })
+}
+
+function placeOsm2WorldBuildings(object, scene) {
+  let fallbackIndex = 0
+  const surfaceRoots = []
+  object.updateMatrixWorld(true)
+  object.traverse((child) => {
+    const surfaceKind = osm2WorldSurfaceKind(child)
+    if (surfaceKind === 'land') {
+      child.visible = false
+      return
+    }
+    if (surfaceKind === 'road' || surfaceKind === 'water') {
+      if (hasOsm2WorldSurfaceAncestor(child, surfaceKind)) return
+      const feature = featureForOsm2WorldObject(
+        child,
+        scene,
+        surfaceRoots.filter((surface) => surface.kind === surfaceKind).length,
+        surfaceKind,
+      )
+      surfaceRoots.push({ root: child, feature, kind: surfaceKind })
+      return
+    }
+    if (!child.name.startsWith('Building')) return
+    const feature = featureForOsm2WorldObject(child, scene, fallbackIndex, 'building')
+    fallbackIndex += 1
+    if (!feature) return
+    const bounds = new THREE.Box3().setFromObject(child)
+    const baseHeight = feature.footprint.reduce((total, point) => total + (point.z || 0), 0) / feature.footprint.length
+    child.position.y += baseHeight - bounds.min.y
+  })
+  object.updateMatrixWorld(true)
+  surfaceRoots.forEach(({ root, feature, kind }) => drapeOsm2WorldSurface(root, scene, feature, kind))
+}
+
+function Osm2WorldModel({ scene, onError, onReady }) {
+  const model = useRef(null)
+  const [object, setObject] = useState(null)
+  const rendering = scene.rendering
+  const fallbackAssetVersion = `${scene.anchor.latitude}:${scene.anchor.longitude}:${scene.size_x}:${scene.size_y}:${scene.features.length}`
+  const assetVersion = rendering?.asset_version || fallbackAssetVersion
+  const url = rendering?.model_file
+    ? `/artifacts/scene/${rendering.model_file}?scene=${encodeURIComponent(assetVersion)}`
+    : null
+  useEffect(() => {
+    if (!url || !rendering?.model_format) return undefined
+    let disposed = false
+    const finish = (asset) => {
+      if (disposed) return
+      const next = asset.scene || asset
+      next.traverse((child) => {
+        if (child.isMesh) {
+          child.castShadow = true
+          child.receiveShadow = true
+        }
+      })
+      alignOsm2WorldModel(next, scene)
+      placeOsm2WorldBuildings(next, scene)
+      model.current = next
+      setObject(next)
+      onReady(osm2WorldSurfaceLayers(next))
+    }
+    const fail = () => {
+      if (!disposed) onError()
+    }
+    if (rendering.model_format !== 'obj') {
+      new GLTFLoader().load(url, finish, undefined, fail)
+    } else {
+      const objLoader = new OBJLoader()
+      const loadObj = () => objLoader.load(url, finish, undefined, fail)
+      const materialUrl = url.replace(/\.obj(\?.*)?$/i, '.mtl$1')
+      new MTLLoader().load(materialUrl, (materials) => {
+        materials.preload()
+        objLoader.setMaterials(materials)
+        loadObj()
+      }, undefined, loadObj)
+    }
+    return () => {
+      disposed = true
+      if (model.current) {
+        model.current.traverse((child) => {
+          child.geometry?.dispose()
+          if (Array.isArray(child.material)) child.material.forEach((material) => material.dispose())
+          else child.material?.dispose()
+        })
+      }
+      model.current = null
+      setObject(null)
+    }
+  }, [onError, onReady, rendering?.model_format, scene, url])
+  if (!object) return null
+  return <primitive object={object} />
+}
+
+function Surface({ feature, terrain, sizeX, sizeY }) {
   const geometry = useMemo(() => {
     const shape = new THREE.Shape()
     feature.footprint.forEach((point, index) => {
@@ -74,10 +309,23 @@ function Surface({ feature }) {
     shape.closePath()
     const result = new THREE.ShapeGeometry(shape)
     result.rotateX(-Math.PI / 2)
+    if (terrain) {
+      const position = new THREE.Vector3()
+      const positions = result.attributes.position
+      for (let index = 0; index < positions.count; index += 1) {
+        position.fromBufferAttribute(positions, index)
+        positions.setY(index, terrainHeightAt(terrain, sizeX, sizeY, position.x, -position.z))
+      }
+      positions.needsUpdate = true
+      result.computeVertexNormals()
+      result.computeBoundingBox()
+      result.computeBoundingSphere()
+    }
     return result
-  }, [feature])
+  }, [feature, sizeX, sizeY, terrain])
+  const baseHeight = terrain ? 0 : feature.footprint.reduce((total, point) => total + (point.z || 0), 0) / feature.footprint.length
   return (
-    <mesh geometry={geometry} position={[0, baseHeight + (feature.category === 'water' ? 0.11 : 0.07), 0]} receiveShadow>
+    <mesh geometry={geometry} position={[0, baseHeight + (feature.category === 'water' ? 0.18 : 0.08), 0]} receiveShadow>
       <meshStandardMaterial
         color={MATERIAL_COLORS[feature.material] || MATERIAL_COLORS.itu_medium_dry_ground}
         roughness={feature.category === 'water' ? 0.28 : 0.96}
@@ -96,39 +344,26 @@ function Terrain({ terrain }) {
     const lowColor = new THREE.Color('#35413c')
     const highColor = new THREE.Color('#647069')
     result.setAttribute('position', new THREE.Float32BufferAttribute(
-      terrain.vertices.flatMap((point) => [point.x, point.z, -point.y]),
-      3,
+      terrain.vertices.flatMap((point) => [point.x, point.z, -point.y]), 3,
     ))
     result.setAttribute('color', new THREE.Float32BufferAttribute(
       terrain.vertices.flatMap((point) => {
         const color = lowColor.clone().lerp(highColor, (point.z - minimum) / range)
         return [color.r, color.g, color.b]
-      }),
-      3,
+      }), 3,
     ))
     result.setIndex(terrain.faces.flat())
     result.computeVertexNormals()
     return result
   }, [terrain])
-  return (
-    <mesh geometry={geometry} receiveShadow>
-      <meshBasicMaterial vertexColors side={THREE.DoubleSide} />
-    </mesh>
-  )
+  return <mesh geometry={geometry} receiveShadow><meshBasicMaterial vertexColors side={THREE.DoubleSide} /></mesh>
 }
 
 function SceneBoundary({ scene }) {
   const points = useMemo(() => {
     if (!scene.terrain) {
-      return [
-        [0, 0.35, 0],
-        [scene.size_x, 0.35, 0],
-        [scene.size_x, 0.35, -scene.size_y],
-        [0, 0.35, -scene.size_y],
-        [0, 0.35, 0],
-      ]
+      return [[0, 0.35, 0], [scene.size_x, 0.35, 0], [scene.size_x, 0.35, -scene.size_y], [0, 0.35, -scene.size_y], [0, 0.35, 0]]
     }
-
     const { rows, columns, vertices } = scene.terrain
     const perimeter = []
     for (let column = 0; column < columns; column += 1) perimeter.push(vertices[column])
@@ -138,16 +373,7 @@ function SceneBoundary({ scene }) {
     perimeter.push(vertices[0])
     return perimeter.map((point) => [point.x, point.z + 0.8, -point.y])
   }, [scene])
-
-  return (
-    <Line
-      points={points}
-      color="#f3a63a"
-      lineWidth={2.2}
-      transparent
-      opacity={0.92}
-    />
-  )
+  return <Line points={points} color="#f3a63a" lineWidth={2.2} transparent opacity={0.92} />
 }
 
 function Drone({ node, selected, onSelect }) {
@@ -158,22 +384,11 @@ function Drone({ node, selected, onSelect }) {
   const position = [node.position[0], node.position[2], -node.position[1]]
   return (
     <group ref={group} position={position} onClick={(event) => { event.stopPropagation(); onSelect(node.id) }}>
-      <mesh castShadow>
-        <sphereGeometry args={[selected ? 3.8 : 3.2, 16, 12]} />
-        <meshStandardMaterial color={selected ? '#f3a63a' : '#d9dee0'} emissive={selected ? '#6a3b08' : '#172124'} />
-      </mesh>
+      <mesh castShadow><sphereGeometry args={[selected ? 3.8 : 3.2, 16, 12]} /><meshStandardMaterial color={selected ? '#f3a63a' : '#d9dee0'} emissive={selected ? '#6a3b08' : '#172124'} /></mesh>
       <mesh rotation={[0, 0, Math.PI / 2]}><cylinderGeometry args={[0.55, 0.55, 15, 8]} /><meshStandardMaterial color="#6f797c" /></mesh>
       <mesh rotation={[Math.PI / 2, 0, 0]}><cylinderGeometry args={[0.55, 0.55, 15, 8]} /><meshStandardMaterial color="#6f797c" /></mesh>
-      {[[7, 0], [-7, 0], [0, 7], [0, -7]].map(([x, z], index) => (
-        <mesh key={index} position={[x, 0, z]} rotation={[0, index * 0.3, 0]}>
-          <cylinderGeometry args={[3.2, 3.2, 0.28, 20]} />
-          <meshStandardMaterial color="#f3a63a" transparent opacity={0.62} />
-        </mesh>
-      ))}
-      <mesh position={[0, -node.position[2] / 2, 0]}>
-        <cylinderGeometry args={[0.12, 0.12, node.position[2], 6]} />
-        <meshBasicMaterial color="#89a7ad" transparent opacity={selected ? 0.32 : 0.12} />
-      </mesh>
+      {[[7, 0], [-7, 0], [0, 7], [0, -7]].map(([x, z], index) => <mesh key={index} position={[x, 0, z]} rotation={[0, index * 0.3, 0]}><cylinderGeometry args={[3.2, 3.2, 0.28, 20]} /><meshStandardMaterial color="#f3a63a" transparent opacity={0.62} /></mesh>)}
+      <mesh position={[0, -node.position[2] / 2, 0]}><cylinderGeometry args={[0.12, 0.12, node.position[2], 6]} /><meshBasicMaterial color="#89a7ad" transparent opacity={selected ? 0.32 : 0.12} /></mesh>
     </group>
   )
 }
@@ -192,39 +407,43 @@ function PacketArc({ arc, nodes }) {
   }, [destination, source])
   useFrame(() => {
     if (!pulse.current || !curve) return
-    const progress = Math.min(1, (Date.now() - arc.createdAt) / 900)
-    pulse.current.position.copy(curve.getPoint(progress))
+    pulse.current.position.copy(curve.getPoint(Math.min(1, (Date.now() - arc.createdAt) / 900)))
   })
   if (!curve) return null
   const color = arc.status === 'failed' ? '#ef5c50' : arc.status === 'success' ? '#46c8b0' : '#f3a63a'
-  return (
-    <group>
-      <Line points={curve.getPoints(30)} color={color} lineWidth={1.4} transparent opacity={0.7} />
-      <mesh ref={pulse}><sphereGeometry args={[1.8, 10, 8]} /><meshBasicMaterial color={color} /></mesh>
-    </group>
-  )
+  return <group><Line points={curve.getPoints(30)} color={color} lineWidth={1.4} transparent opacity={0.7} /><mesh ref={pulse}><sphereGeometry args={[1.8, 10, 8]} /><meshBasicMaterial color={color} /></mesh></group>
 }
 
 export default function SceneViewport({ scene, nodes, arcs, selectedNode, onSelectNode }) {
+  const [modelFailed, setModelFailed] = useState(false)
+  const [modelLoaded, setModelLoaded] = useState(false)
+  const [modelLayers, setModelLayers] = useState({ road: false, water: false })
+  const hasOsm2WorldModel = scene.rendering?.status === 'rendered' && Boolean(scene.rendering.model_file)
+  useEffect(() => {
+    setModelFailed(false)
+    setModelLoaded(false)
+    setModelLayers({ road: false, water: false })
+  }, [scene])
+  const handleModelError = useCallback(() => {
+    setModelLayers({ road: false, water: false })
+    setModelFailed(true)
+  }, [])
+  const handleModelReady = useCallback((layers) => {
+    setModelLayers(layers)
+    setModelLoaded(true)
+  }, [])
+  const detailedModelActive = hasOsm2WorldModel && !modelFailed && modelLoaded
   return (
     <Canvas shadows dpr={[1, 1.7]} camera={{ fov: 46, near: 0.5, far: 5000 }}>
-      <color attach="background" args={['#171a1c']} />
-      <fog attach="fog" args={['#171a1c', 650, 1600]} />
-      <ambientLight intensity={0.58} />
-      <directionalLight position={[250, 500, 180]} intensity={1.9} castShadow shadow-mapSize={[2048, 2048]} />
-      {scene.terrain
-        ? <Terrain terrain={scene.terrain} />
-        : <mesh position={[scene.size_x / 2, -0.2, -scene.size_y / 2]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
-          <planeGeometry args={[scene.size_x + 100, scene.size_y + 100]} />
-          <meshStandardMaterial color="#24282a" roughness={0.92} />
-        </mesh>}
+      <color attach="background" args={['#171a1c']} /><fog attach="fog" args={['#171a1c', 650, 1600]} />
+      <ambientLight intensity={0.58} /><directionalLight position={[250, 500, 180]} intensity={1.9} castShadow shadow-mapSize={[2048, 2048]} />
+      {scene.terrain ? <Terrain terrain={scene.terrain} /> : <mesh position={[scene.size_x / 2, -0.2, -scene.size_y / 2]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow><planeGeometry args={[scene.size_x + 100, scene.size_y + 100]} /><meshStandardMaterial color="#24282a" roughness={0.92} /></mesh>}
       {!scene.terrain && <Grid position={[scene.size_x / 2, 0, -scene.size_y / 2]} args={[scene.size_x, scene.size_y]} cellSize={20} cellThickness={0.45} cellColor="#42494b" sectionSize={100} sectionThickness={0.8} sectionColor="#5d6668" fadeDistance={900} />}
       <SceneBoundary scene={scene} />
-      {scene.features.filter((feature) => feature.category === 'building').map((feature) => <Building key={feature.id} feature={feature} />)}
-      {scene.features.filter((feature) => feature.category === 'water' || (!scene.terrain && feature.category === 'terrain')).map((feature) => <Surface key={feature.id} feature={feature} />)}
-      {scene.features.filter((feature) => feature.category === 'road').map((feature) => (
-        <Line key={feature.id} points={feature.footprint.map((point) => [point.x, (point.z || 0) + 0.22, -point.y])} color="#697173" lineWidth={3} />
-      ))}
+      {hasOsm2WorldModel && !modelFailed && <Osm2WorldModel scene={scene} onError={handleModelError} onReady={handleModelReady} />}
+      {(!hasOsm2WorldModel || modelFailed || !modelLoaded) && scene.features.filter((feature) => feature.category === 'building').map((feature) => <Building key={feature.id} feature={feature} />)}
+      {scene.features.filter((feature) => ((feature.category === 'water' && (!detailedModelActive || !modelLayers.water)) || (!scene.terrain && feature.category === 'terrain'))).map((feature) => <Surface key={feature.id} feature={feature} terrain={scene.terrain} sizeX={scene.size_x} sizeY={scene.size_y} />)}
+      {scene.features.filter((feature) => feature.category === 'road' && (!detailedModelActive || !modelLayers.road)).map((feature) => <Line key={feature.id} points={feature.footprint.map((point) => [point.x, (scene.terrain ? terrainHeightAt(scene.terrain, scene.size_x, scene.size_y, point.x, point.y) : point.z || 0) + 0.22, -point.y])} color="#697173" lineWidth={3} />)}
       {nodes.map((node) => <Drone key={node.id} node={node} selected={selectedNode === node.id} onSelect={onSelectNode} />)}
       {arcs.map((arc) => <PacketArc key={`${arc.id}-${arc.destination}`} arc={arc} nodes={nodes} />)}
       <CameraTarget scene={scene} />

--- a/main.py
+++ b/main.py
@@ -36,15 +36,28 @@ def run_simulation(arguments):
 
 def compile_scene_file(arguments):
     scene = SceneModel.model_validate_json(Path(arguments.input).read_text(encoding="utf-8"))
-    print(compile_scene(scene, arguments.output))
+    print(compile_scene(
+        scene,
+        arguments.output,
+        osm2world_jar=arguments.osm2world_jar,
+        enable_osm2world=not arguments.no_osm2world,
+    ))
 
 
 def import_osm(arguments):
     bounds = GeoBounds(south=arguments.south, west=arguments.west,
                        north=arguments.north, east=arguments.east)
     scene = fetch_osm_scene(bounds, arguments.name)
-    compile_scene(scene, arguments.output)
-    print(json.dumps(scene.model_dump(), indent=2))
+    compile_scene(
+        scene,
+        arguments.output,
+        osm2world_jar=arguments.osm2world_jar,
+        enable_osm2world=not arguments.no_osm2world,
+    )
+    compiled_scene = SceneModel.model_validate_json(
+        (Path(arguments.output) / "scene.json").read_text(encoding="utf-8")
+    )
+    print(json.dumps(compiled_scene.model_dump(), indent=2))
 
 
 def parser():
@@ -70,6 +83,8 @@ def parser():
     compile_command = commands.add_parser("compile-scene")
     compile_command.add_argument("input")
     compile_command.add_argument("--output", default="artifacts/scene")
+    compile_command.add_argument("--osm2world-jar", default=None)
+    compile_command.add_argument("--no-osm2world", action="store_true")
     compile_command.set_defaults(handler=compile_scene_file)
 
     osm = commands.add_parser("import-osm")
@@ -79,6 +94,8 @@ def parser():
     osm.add_argument("--east", type=float, required=True)
     osm.add_argument("--name", default="OSM Scene")
     osm.add_argument("--output", default="artifacts/scene")
+    osm.add_argument("--osm2world-jar", default=None)
+    osm.add_argument("--no-osm2world", action="store_true")
     osm.set_defaults(handler=import_osm)
     return root
 

--- a/scene/compiler.py
+++ b/scene/compiler.py
@@ -8,6 +8,7 @@ from shapely.geometry import Polygon
 from shapely.validation import make_valid
 
 from scene.models import SceneModel
+from scene.osm2world import enrich_scene, render_osm2world
 
 
 ITU_TYPES = {
@@ -78,8 +79,10 @@ def _write_xml(meshes, materials, output_directory):
     return xml_path
 
 
-def compile_scene(scene: SceneModel, output_directory, progress=None):
+def compile_scene(scene: SceneModel, output_directory, progress=None, osm2world_jar=None,
+                  enable_osm2world=True, asset_version=None):
     progress = progress or (lambda _value, _stage: None)
+    scene = enrich_scene(scene)
     output_directory = Path(output_directory)
     mesh_directory = output_directory / "meshes"
     mesh_directory.mkdir(parents=True, exist_ok=True)
@@ -106,7 +109,17 @@ def compile_scene(scene: SceneModel, output_directory, progress=None):
             0.05 + 0.85 * (index + 1) / max(1, len(compiled_features)),
             f"Meshing {feature.category} features",
         )
-    progress(0.93, "Writing Sionna scene")
+    progress(0.91, "Preparing OSM2World building metadata")
+    rendering = render_osm2world(
+        scene,
+        output_directory,
+        progress=progress,
+        jar=osm2world_jar,
+        enabled=enable_osm2world,
+        asset_version=asset_version,
+    )
+    scene = scene.model_copy(update={"rendering": rendering})
+    progress(0.97, "Writing Sionna scene")
     scene_path = output_directory / "scene.json"
     scene_path.write_text(scene.model_dump_json(indent=2), encoding="utf-8")
     xml_path = _write_xml(meshes, materials, output_directory)
@@ -123,6 +136,7 @@ def compile_scene(scene: SceneModel, output_directory, progress=None):
             "resolution_m": scene.terrain.resolution_m,
             "source": scene.terrain.source,
         } if scene.terrain else None,
+        "rendering": rendering.model_dump(),
     }
     (output_directory / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
     progress(1.0, "Sionna scene ready")

--- a/scene/models.py
+++ b/scene/models.py
@@ -34,6 +34,8 @@ class SceneFeature(BaseModel):
     height: float = Field(default=0.0, ge=0.0)
     material: str = "itu_concrete"
     source: str = "user"
+    osm_id: str | None = None
+    osm_tags: dict[str, str] = Field(default_factory=dict)
 
 
 class TerrainMesh(BaseModel):
@@ -46,6 +48,16 @@ class TerrainMesh(BaseModel):
     source: str
 
 
+class SceneRendering(BaseModel):
+    renderer: str = "none"
+    status: Literal["not_requested", "not_available", "rendered", "failed"] = "not_requested"
+    osm_file: str | None = None
+    model_file: str | None = None
+    model_format: Literal["glb", "gltf", "obj"] | None = None
+    asset_version: str | None = None
+    message: str | None = None
+
+
 class SceneModel(BaseModel):
     schema_version: int = 1
     name: str
@@ -55,3 +67,4 @@ class SceneModel(BaseModel):
     size_y: float = Field(gt=0)
     features: list[SceneFeature] = Field(default_factory=list)
     terrain: TerrainMesh | None = None
+    rendering: SceneRendering | None = None

--- a/scene/osm2world.py
+++ b/scene/osm2world.py
@@ -1,0 +1,337 @@
+"""OSM enrichment and optional OSM2World rendering.
+
+The simulator uses the compact :class:`SceneModel` as its source of truth. This
+module creates a standards-shaped OSM view of that model for visual rendering;
+the generated file is deliberately not used to build the Sionna collision or
+radio meshes.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import shutil
+import subprocess
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from uuid import uuid4
+
+from scene.models import SceneFeature, SceneModel, SceneRendering
+
+
+OSM_NAMESPACE = "http://openstreetmap.org/osm/0.6"
+ET.register_namespace("", OSM_NAMESPACE)
+
+MATERIAL_TAGS = {
+    "itu_concrete": "concrete",
+    "itu_brick": "brick",
+    "itu_glass": "glass",
+    "itu_metal": "metal",
+    "itu_wood": "wood",
+}
+ROOF_MATERIALS = {
+    "concrete": "concrete",
+    "brick": "roof_tiles",
+    "glass": "glass",
+    "metal": "metal",
+    "wood": "wood",
+}
+ROOF_SHAPES = {"flat", "gabled", "hipped", "pyramidal", "skillion", "mansard", "dome", "round"}
+
+
+def _project_root():
+    return Path(__file__).resolve().parents[1]
+
+
+def _project_java():
+    """Return the project-local Java runtime when it has been installed."""
+    java_root = _project_root() / "tools" / "java"
+    candidates = [java_root / "bin" / "java.exe", java_root / "bin" / "java"]
+    candidates.extend(java_root.glob("*/bin/java.exe"))
+    candidates.extend(java_root.glob("*/bin/java"))
+    return next((path.resolve() for path in candidates if path.is_file()), None)
+
+
+def _project_osm2world_jars():
+    package_root = _project_root() / "tools" / "osm2world"
+    return sorted(
+        (path.resolve() for path in package_root.rglob("*.jar") if path.is_file()),
+        key=lambda path: ("osm2world" not in path.name.lower(), len(path.parts), path.name),
+    )
+
+
+def _java_command():
+    configured_java = os.environ.get("JAVA")
+    if configured_java:
+        configured_path = Path(configured_java).expanduser()
+        if configured_path.is_file():
+            return str(configured_path.resolve())
+        if shutil.which(configured_java):
+            return configured_java
+    bundled_java = _project_java()
+    return str(bundled_java) if bundled_java else "java"
+
+
+def _polygon_dimensions(feature: SceneFeature):
+    points = [(point.x, point.y) for point in feature.footprint]
+    if len(points) < 2:
+        return 1.0, 1.0, 0.0
+    edges = [
+        (math.dist(start, end), start, end)
+        for start, end in zip(points, points[1:] + points[:1])
+    ]
+    longest, start, end = max(edges, key=lambda item: item[0])
+    shortest = max(1.0, min(edge[0] for edge in edges))
+    direction = (math.degrees(math.atan2(end[0] - start[0], end[1] - start[1])) + 360.0) % 360.0
+    return max(1.0, longest), shortest, direction
+
+
+def _default_roof_shape(feature: SceneFeature):
+    longest, shortest, _direction = _polygon_dimensions(feature)
+    aspect_ratio = longest / shortest
+    if feature.height >= 60.0:
+        return "flat"
+    if aspect_ratio >= 1.6:
+        return "gabled"
+    return "hipped"
+
+
+def complete_osm_tags(feature: SceneFeature) -> dict[str, str]:
+    """Return OSM tags while leaving unspecified visual materials to OSM2World."""
+    tags = {str(key): str(value) for key, value in feature.osm_tags.items()}
+    if feature.category == "building":
+        material = MATERIAL_TAGS.get(feature.material)
+        tags.setdefault("building", "yes")
+        tags.setdefault("height", f"{max(feature.height, 1.0):.2f}")
+        tags.setdefault("min_height", "0")
+        levels = max(1, round(max(feature.height, 3.2) / 3.2))
+        tags.setdefault("building:levels", str(levels))
+        tags.setdefault("building:levels:aboveground", tags["building:levels"])
+        if feature.source != "openstreetmap" and material:
+            tags.setdefault("building:material", material)
+            tags.setdefault("facade:material", material)
+
+        roof_shape = tags.get("roof:shape", "").lower()
+        if roof_shape not in ROOF_SHAPES:
+            roof_shape = _default_roof_shape(feature)
+        tags["roof:shape"] = roof_shape
+        if feature.source != "openstreetmap" and material:
+            tags.setdefault("roof:material", ROOF_MATERIALS.get(material, "concrete"))
+        if roof_shape == "flat":
+            tags.setdefault("roof:height", "0")
+            tags.setdefault("roof:levels", "0")
+        else:
+            roof_height = min(6.0, max(2.0, feature.height * 0.16))
+            tags.setdefault("roof:height", f"{roof_height:.2f}")
+            tags.setdefault("roof:levels", "1")
+            longest, shortest, direction = _polygon_dimensions(feature)
+            tags.setdefault("roof:direction", f"{direction:.1f}")
+            tags.setdefault("roof:orientation", "along" if longest / shortest >= 1.5 else "across")
+            angle = math.degrees(math.atan2(roof_height, max(0.5, shortest / 2.0)))
+            tags.setdefault("roof:angle", f"{min(45.0, max(5.0, angle)):.1f}")
+        tags.setdefault("layer", "0")
+    elif feature.category == "road":
+        tags.setdefault("highway", "service")
+        tags.setdefault("surface", "asphalt")
+        tags.setdefault("lanes", "2")
+        tags.setdefault("width", "8")
+        tags.setdefault("layer", "0")
+    elif feature.category == "water":
+        tags.setdefault("natural", "water")
+        tags.setdefault("water", "lake")
+        tags.setdefault("surface", "water")
+    elif feature.category == "terrain":
+        tags.setdefault("natural", "grassland")
+        tags.setdefault("surface", "grass")
+    tags.setdefault("source", feature.source)
+    return tags
+
+
+def enrich_scene(scene: SceneModel) -> SceneModel:
+    """Add OSM metadata without changing simulation geometry or material IDs."""
+    features = [
+        feature.model_copy(update={"osm_tags": complete_osm_tags(feature)})
+        for feature in scene.features
+    ]
+    return scene.model_copy(update={"features": features, "rendering": None})
+
+
+def _inverse_enu(x, y, scene: SceneModel):
+    latitude = scene.anchor.latitude + y / 110574.0
+    metres_per_degree_longitude = math.cos(math.radians(scene.anchor.latitude)) * 111320.0
+    longitude = scene.anchor.longitude + x / metres_per_degree_longitude
+    return latitude, longitude
+
+
+def _node_id(index):
+    return str(-1_000_000_000 - index)
+
+
+def _way_id(index):
+    return str(-2_000_000_000 - index)
+
+
+def write_osm(scene: SceneModel, path) -> Path:
+    """Write a valid OSM 0.6 XML view of the scene."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    root = ET.Element(
+        f"{{{OSM_NAMESPACE}}}osm",
+        {"version": "0.6", "generator": "UavNetSim OSM2World adapter"},
+    )
+    northeast_latitude, northeast_longitude = _inverse_enu(scene.size_x, scene.size_y, scene)
+    ET.SubElement(root, f"{{{OSM_NAMESPACE}}}bounds", {
+        "minlat": str(scene.anchor.latitude),
+        "minlon": str(scene.anchor.longitude),
+        "maxlat": str(northeast_latitude),
+        "maxlon": str(northeast_longitude),
+    })
+
+    node_index = 0
+    for feature_index, feature in enumerate(scene.features):
+        if len(feature.footprint) < 2:
+            continue
+        tags = complete_osm_tags(feature)
+        points = list(feature.footprint)
+        is_closed = feature.category != "road"
+        if is_closed and len(points) > 1 and points[0] == points[-1]:
+            points = points[:-1]
+        node_ids = []
+        for point in points:
+            node_id = _node_id(node_index)
+            node_index += 1
+            latitude, longitude = _inverse_enu(point.x, point.y, scene)
+            node = ET.SubElement(root, f"{{{OSM_NAMESPACE}}}node", {
+                "id": node_id,
+                "lat": f"{latitude:.9f}",
+                "lon": f"{longitude:.9f}",
+                "version": "1",
+            })
+            if point.z:
+                ET.SubElement(node, f"{{{OSM_NAMESPACE}}}tag", {"k": "ele", "v": f"{point.z:.2f}"})
+            node_ids.append(node_id)
+        if is_closed and node_ids:
+            node_ids.append(node_ids[0])
+        way = ET.SubElement(root, f"{{{OSM_NAMESPACE}}}way", {
+            "id": _way_id(feature_index),
+            "version": "1",
+        })
+        for node_id in node_ids:
+            ET.SubElement(way, f"{{{OSM_NAMESPACE}}}nd", {"ref": node_id})
+        for key, value in sorted(tags.items()):
+            ET.SubElement(way, f"{{{OSM_NAMESPACE}}}tag", {"k": key, "v": value})
+
+    ET.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+    return path
+
+
+def _configured_command(jar=None):
+    jar = jar or os.environ.get("OSM2WORLD_JAR")
+    if not jar:
+        project_jars = _project_osm2world_jars()
+        if project_jars:
+            jar = str(project_jars[0])
+    executable = os.environ.get("OSM2WORLD_BIN") or os.environ.get("OSM2WORLD_EXECUTABLE")
+    if jar:
+        jar_path = Path(jar).expanduser().resolve()
+        if jar_path.is_file():
+            return [
+                _java_command(),
+                "--add-exports", "java.base/java.lang=ALL-UNNAMED",
+                "--add-exports", "java.desktop/sun.awt=ALL-UNNAMED",
+                "--add-exports", "java.desktop/sun.java2d=ALL-UNNAMED",
+                "-jar", str(jar_path),
+            ]
+        return None
+    if executable:
+        executable_path = Path(executable).expanduser()
+        if executable_path.is_file():
+            return [str(executable_path.resolve())]
+        return [executable] if shutil.which(executable) else None
+    for candidate in ("osm2world", "osm2world.bat", "osm2world.exe"):
+        if shutil.which(candidate):
+            return [candidate]
+    return None
+
+
+def render_osm2world(scene: SceneModel, output_directory, progress=None, jar=None, enabled=True,
+                     asset_version=None):
+    """Write enriched OSM and optionally invoke OSM2World.
+
+    Rendering is best-effort by design. A missing Java/JAR or an unsupported
+    OSM2World output format must never prevent the Sionna scene from compiling.
+    """
+    progress = progress or (lambda _value, _stage: None)
+    output_directory = Path(output_directory)
+    asset_version = asset_version or f"build-{uuid4().hex}"
+    render_directory = output_directory / "osm2world"
+    render_directory.mkdir(parents=True, exist_ok=True)
+    for stale_path in render_directory.glob("scene.*"):
+        if stale_path.name != "scene.osm":
+            stale_path.unlink(missing_ok=True)
+    osm_path = write_osm(scene, (render_directory / "scene.osm").resolve())
+    output_directory = output_directory.resolve()
+    render_directory = render_directory.resolve()
+    relative_osm = osm_path.relative_to(output_directory).as_posix()
+    base = {
+        "renderer": "osm2world",
+        "status": "not_available" if enabled else "not_requested",
+        "osm_file": relative_osm,
+        "model_file": None,
+        "model_format": None,
+        "asset_version": asset_version,
+        "message": "OSM2World was not requested",
+    }
+    if not enabled:
+        return SceneRendering(**base)
+    command = _configured_command(jar)
+    if command is None:
+        base["message"] = "OSM2World JAR or executable not found; generated OSM is ready"
+        return SceneRendering(**base)
+
+    timeout = max(1, int(os.environ.get("OSM2WORLD_TIMEOUT_SECONDS", "180")))
+    command_cwd = render_directory
+    if "-jar" in command:
+        jar_index = command.index("-jar") + 1
+        if jar_index < len(command):
+            command_cwd = Path(command[jar_index]).resolve().parent
+    progress(0.94, "Rendering detailed buildings with OSM2World")
+    errors = []
+    for extension in ("glb", "gltf", "obj"):
+        output_path = render_directory / f"scene.{extension}"
+        output_path.unlink(missing_ok=True)
+        attempts = (
+            command + ["convert", f"--input={osm_path}", f"--output={output_path}"],
+            command + ["--input", str(osm_path), "--output", str(output_path)],
+            command + [f"--input={osm_path}", f"--output={output_path}"],
+            command + [str(osm_path), "-o", str(output_path)],
+        )
+        for attempt in attempts:
+            try:
+                result = subprocess.run(
+                    attempt,
+                    cwd=command_cwd,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                    check=False,
+                )
+            except (OSError, subprocess.TimeoutExpired) as error:
+                errors.append(str(error))
+                continue
+            if result.returncode == 0 and output_path.is_file() and output_path.stat().st_size > 0:
+                relative_model = output_path.relative_to(output_directory).as_posix()
+                return SceneRendering(
+                    renderer="osm2world",
+                    status="rendered",
+                    osm_file=relative_osm,
+                    model_file=relative_model,
+                    model_format=extension,
+                    asset_version=asset_version,
+                    message="OSM2World model generated",
+                )
+            details = (result.stderr or result.stdout or f"exit code {result.returncode}").strip()
+            errors.append(f"{extension}: {details[-500:]}")
+    base["status"] = "failed"
+    base["message"] = "OSM2World failed: " + " | ".join(errors)[-1500:]
+    return SceneRendering(**base)

--- a/scene/osm_importer.py
+++ b/scene/osm_importer.py
@@ -50,7 +50,7 @@ def _height(tags):
             return max(1.0, float(levels) * 3.2)
         except ValueError:
             pass
-    building_type = tags.get("building", "")
+    building_type = tags.get("building", tags.get("building:part", ""))
     if building_type in {"office", "commercial", "apartments"}:
         return 18.0
     if building_type in {"industrial", "warehouse"}:
@@ -59,7 +59,16 @@ def _height(tags):
 
 
 def _material(tags):
-    raw = tags.get("building:material", tags.get("material", "")).lower()
+    raw = tags.get(
+        "facade:material",
+        tags.get(
+            "building:facade:material",
+            tags.get(
+                "building:wall:material",
+                tags.get("building:material", tags.get("material", "")),
+            ),
+        ),
+    ).lower()
     return MATERIALS.get(raw, "itu_concrete")
 
 
@@ -67,8 +76,12 @@ def _tagged(tags, choices):
     return any(tags.get(key) == value for key, value in choices)
 
 
+def _osm_tags(tags):
+    return {str(key): str(value) for key, value in tags.items()}
+
+
 def _feature_kind(tags):
-    if tags.get("building"):
+    if tags.get("building") or tags.get("building:part"):
         return "building", _material(tags), _height(tags)
     if tags.get("highway"):
         return "road", "itu_concrete", 0.0
@@ -84,7 +97,9 @@ def _query(bounds: GeoBounds):
     return f"""[out:json][timeout:30];
 (
   way[\"building\"]({box});
+  way[\"building:part\"]({box});
   relation[\"building\"]({box});
+  relation[\"building:part\"]({box});
   way[\"highway\"]({box});
   way[\"natural\"~\"^(grassland|heath|water)$\"]({box});
   relation[\"natural\"~\"^(grassland|heath|water)$\"]({box});
@@ -205,6 +220,8 @@ def parse_osm_scene(payload, bounds: GeoBounds, name="OSM Scene", progress=None)
                 height=height,
                 material=material,
                 source="openstreetmap",
+                osm_id=f"way/{element['id']}",
+                osm_tags=_osm_tags(tags),
             ))
     for relation in elements:
         if relation.get("type") != "relation":
@@ -229,6 +246,8 @@ def parse_osm_scene(payload, bounds: GeoBounds, name="OSM Scene", progress=None)
                     height=height,
                     material=material,
                     source="openstreetmap",
+                    osm_id=f"relation/{relation['id']}",
+                    osm_tags=_osm_tags(tags),
                 ))
     progress(0.95, "Finalizing geospatial model")
     northeast = lat_lon_to_enu(bounds.north, bounds.east, anchor)

--- a/tools/osm2world/run-osm2world.cmd
+++ b/tools/osm2world/run-osm2world.cmd
@@ -1,0 +1,25 @@
+@echo off
+setlocal
+
+set "PROJECT_ROOT=%~dp0..\.."
+set "JAVA_EXE="
+if exist "%PROJECT_ROOT%\tools\java\bin\java.exe" set "JAVA_EXE=%PROJECT_ROOT%\tools\java\bin\java.exe"
+if not defined JAVA_EXE for /d %%D in ("%PROJECT_ROOT%\tools\java\*") do if exist "%%~fD\bin\java.exe" if not defined JAVA_EXE set "JAVA_EXE=%%~fD\bin\java.exe"
+if not exist "%JAVA_EXE%" (
+  echo Project-local Java was not found under tools\java.
+  exit /b 1
+)
+
+set "OSM2WORLD_JAR="
+for /r "%~dp0" %%F in (*osm2world*.jar) do if not defined OSM2WORLD_JAR set "OSM2WORLD_JAR=%%F"
+if not defined OSM2WORLD_JAR for /r "%~dp0" %%F in (*.jar) do if not defined OSM2WORLD_JAR set "OSM2WORLD_JAR=%%F"
+if not defined OSM2WORLD_JAR (
+  echo OSM2World JAR was not found under tools\osm2world.
+  exit /b 1
+)
+
+pushd "%~dp0"
+"%JAVA_EXE%" --add-exports java.base/java.lang=ALL-UNNAMED --add-exports java.desktop/sun.awt=ALL-UNNAMED --add-exports java.desktop/sun.java2d=ALL-UNNAMED -jar "%OSM2WORLD_JAR%" %*
+set "EXIT_CODE=%ERRORLEVEL%"
+popd
+exit /b %EXIT_CODE%


### PR DESCRIPTION
## Summary\n\n- add optional OSM2World rendering for detailed buildings, roofs, roads, and surfaces\n- preserve the existing Sionna scene and automatically fall back when Java or OSM2World is unavailable\n- document OSM2World latest-build and Java 17 JRE ZIP installation in English and Chinese\n- keep external OSM2World and Java runtime files out of Git\n\n## Verification\n\n- Python tests: 17 passed\n- frontend lint: passed with one existing ScenePicker hooks warning\n- frontend build: passed\n- default scene compile with --no-osm2world: passed\n\nCloses the unrelated-history comparison issue by using a branch based on upstream/master.